### PR TITLE
集合modを作成

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@
 //!
 
 pub mod geometry;
+pub mod set;

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -25,6 +25,6 @@ fn test_set() {
     let natural = Natural::new();
     let even = Even::new();
     let odd = Odd::new();
-    let one_digit_nums = Set::new([1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    let natural_even = Set::union(natural, even);
+    let one_digit_natural_nums = Set::new([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let natural_even = Set::union(Natural, Even); // nextが持てない
 }

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -1,5 +1,30 @@
-pub struct Natural {}
+// pub struct Natural {
+//     current_value: u128,
+// }
 
-impl Iterator for Natural {
-    fn next(&self) -> Self {}
+// pub trait Set<T> {
+//     fn is_valid(value: T) -> bool;
+// }
+
+// impl Iterator for Natural {
+//     type Item = u128;
+
+//     fn next(&mut self) -> Option<Self::Item> {
+//         Some(self.current_value)
+//     }
+// }
+
+// impl Natural {
+//     fn new() -> Natural {
+//         Natural { current_value: 0 }
+//     }
+// }
+
+#[test]
+fn test_set() {
+    let natural = Natural::new();
+    let even = Even::new();
+    let odd = Odd::new();
+    let one_digit_nums = Set::new([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    let natural_even = Set::union(natural, even);
 }

--- a/src/set/mod.rs
+++ b/src/set/mod.rs
@@ -1,0 +1,5 @@
+pub struct Natural {}
+
+impl Iterator for Natural {
+    fn next(&self) -> Self {}
+}


### PR DESCRIPTION
TODO
- [ ] 空集合
- [ ] 無限集合は判定式のみを持つ

問題点
* 無限集合を認めると、その他の全ての扱いが困難になる
* 有限集合のみであれば、通常の配列のほうが操作性があるかも？
